### PR TITLE
add concurrency property to workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   build:
+    concurrency: 
+      group: ${{ github.ref }}
+      cancel-in-progress: true
     runs-on: ubuntu-latest
     if: github.repository_owner == 'kittrgg'
     steps:
@@ -74,6 +77,9 @@ jobs:
     #     min-versions-to-keep: 3
 
   deploy:
+    concurrency: 
+      group: ${{ github.ref }}
+      cancel-in-progress: true
     needs: build
     runs-on: ubuntu-latest
     if: github.repository_owner == 'kittrgg'
@@ -97,6 +103,9 @@ jobs:
             dokku git:from-image stage-web ghcr.io/${{github.repository}}/web:test-${{github.sha}}
 
   e2e:
+    concurrency: 
+      group: ${{ github.ref }}
+      cancel-in-progress: true
     needs: deploy
     runs-on: ubuntu-latest
     if: github.repository_owner == 'kittrgg'


### PR DESCRIPTION
closes #106 

There are few Github Actions to cancel duplicate running actions ([1](https://github.com/fkirc/skip-duplicate-actions), [2](https://github.com/styfle/cancel-workflow-action)) but there is now an Workflow API property ``concurrency`` to ensure that only one action is running on the same Github Reference: [https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency)

Basically, adding: 
```yml
concurrency: 
  group: ${{ github.ref }}
  cancel-in-progress: true
```
 should cancel previous actions

but this PR **NEEDS TO BE TESTED**